### PR TITLE
Strip null-terminator from PacketVersionSend.operatingsystem

### DIFF
--- a/src/network.c
+++ b/src/network.c
@@ -1179,7 +1179,7 @@ static void getPacketVersionGet(uint8_t * data, size_t len) {
     reply.operatingsystem = operatingsystem;
 
     if (settings.report_client_version || HACKS_ENABLED)
-        sendPacketVersionSend(&reply, sizeof(operatingsystem));
+        sendPacketVersionSend(&reply, sizeof(operatingsystem)-1);
 }
 
 static void getPacketPlayerProperties(uint8_t * data, size_t len) {


### PR DESCRIPTION
OpenSpades and BetterSpades both send it unterminated, relying on enet's packet->dataLength instead.

- https://github.com/yvt/openspades/wiki/Network-Protocols#:~:text=NOT%20end%20with%20a%20null
- https://raw.githubusercontent.com/xtreme8000/BetterSpades/standalone/src/network.c#:~:text=strlen(os)